### PR TITLE
feat(executors): add react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.5",
   "description": "A unraid nodejs API",
   "main": "dist/index.js",
+  "files": [
+    "dist/**"
+  ],
   "author": "Tom Sacher",
   "license": "MIT",
   "private": false,
@@ -24,8 +27,9 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "ts-mixer": "^6.0.0",
-    "ssh2": "^1.5.0"
+    "react-native-ssh-sftp": "^1.0.3",
+    "ssh2": "^1.5.0",
+    "ts-mixer": "^6.0.0"
   },
   "scripts": {
     "release": "release-it"

--- a/src/executors/ReactNativeSSH.ts
+++ b/src/executors/ReactNativeSSH.ts
@@ -1,0 +1,60 @@
+import SSHClient from 'react-native-ssh-sftp';
+import { executor as Executor } from '../instance';
+
+export type SSHConfig = {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+};
+
+export class ReactNativeExecutor extends Executor.Executor<SSHConfig> {
+  private connection: SSHClient;
+
+  private ready = false;
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.connection = new SSHClient(
+        this.config.host,
+        this.config.port,
+        this.config.username,
+        this.config.password,
+        (error) => {
+          if (error) reject(error);
+          this.ready = true;
+          resolve();
+        }
+      );
+    });
+  }
+
+  disconnect(): void {
+    this.connection.disconnect();
+  }
+
+  execute(command: Executor.IExecuteSimple): Promise<Executor.IExecuteResult>;
+
+  execute({ command }: Executor.IExecute): Promise<Executor.IExecuteResult>;
+
+  execute(command: Executor.IExecuteSimple | Executor.IExecute): Promise<Executor.IExecuteResult>;
+
+  async execute(command: Executor.IExecuteSimple | Executor.IExecute): Promise<Executor.IExecuteResult> {
+    if (!this.ready) await this.connect();
+    return new Promise((resolve, reject) => {
+      if (typeof command === 'object') command = command.command;
+      this.connection.execute(command, (error, output) => {
+        if (error) reject(error);
+        const response = {
+          stderr: [],
+          stdout: output.split('\n'),
+        };
+        resolve({
+          ...response,
+          code: 0,
+          signal: 0,
+        });
+      });
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "outDir": "dist",
     "declaration": true
   },
-  "exclude": ["node_modules", "examples"]
+  "exclude": ["node_modules", "examples", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,6 +2909,11 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-native-ssh-sftp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-ssh-sftp/-/react-native-ssh-sftp-1.0.3.tgz#42c4a0e5c12d3c64cec605ded62dabd83253794d"
+  integrity sha1-QsSg5cEtPGTOxgXe1i2r2DJTeU0=
+
 read-pkg-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"


### PR DESCRIPTION
Unfortunately, the `react-native-ssh-sftp` currently does not return the signal and code. Also, there is no way to find out if the connection is aborted. We might need to fork it later on and continue development there.