### PR TITLE
fix(cpu): cpu count on 100% load on core

### DIFF
--- a/src/modules/system/extensions/cpu.ts
+++ b/src/modules/system/extensions/cpu.ts
@@ -54,7 +54,7 @@ export class SystemModuleCpuExtension extends SystemModuleExtensionBase {
     private static cpuUsageCommand = `COLUMNS=200 TERM=dumb top -1 -n 1 -b | grep '^%Cpu[[:digit:]+]' | tr '\n' '|'`;
 
     private static cpuLineRegex =
-        /%Cpu(?<cpu_core>\d+)\s+:\s+(?<user>\d+.\d+(?=\s+us)).*?,\s*(?<system>\d+.\d+(?=\s+sy)).*?,\s*(?<nice>\d+.\d+(?=\s+ni)).*?,\s*(?<idle>\d+.\d+(?=\s+id)).*?,\s*(?<io_wait>\d+.\d+(?=\s+wa)).*?,\s*(?<hardware_interrupts>\d+.\d+(?=\s+hi)).*?,\s*(?<software_interrupts>\d+.\d+(?=\s+si)).*?,\s*(?<steal>\d+.\d+(?=\s+st))/gm;
+        /%Cpu(?<cpu_core>\d+)\s+:\s*(?<user>\d+.\d+(?=\s+us)).*?,\s*(?<system>\d+.\d+(?=\s+sy)).*?,\s*(?<nice>\d+.\d+(?=\s+ni)).*?,\s*(?<idle>\d+.\d+(?=\s+id)).*?,\s*(?<io_wait>\d+.\d+(?=\s+wa)).*?,\s*(?<hardware_interrupts>\d+.\d+(?=\s+hi)).*?,\s*(?<software_interrupts>\d+.\d+(?=\s+si)).*?,\s*(?<steal>\d+.\d+(?=\s+st))/gm;
 
     async usage(): Promise<CPUUsage> {
         const { code, stdout } = await this.instance.execute(SystemModuleCpuExtension.cpuUsageCommand);


### PR DESCRIPTION
This line didn't parse correctly, because of the missing space after the `:`:

```
%Cpu1  :100.0 us,  0.0 sy,  0.0 ni,  0.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
```